### PR TITLE
Add supports(Database) method to satisfy validation requirement

### DIFF
--- a/src/main/java/liquibase/ext/mssql/change/LoadDataChangeMssql.java
+++ b/src/main/java/liquibase/ext/mssql/change/LoadDataChangeMssql.java
@@ -4,6 +4,7 @@ import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.change.core.LoadDataChange;
 import liquibase.database.Database;
+import liquibase.database.core.MSSQLDatabase;
 import liquibase.ext.mssql.MssqlUtil;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -44,5 +45,10 @@ public class LoadDataChangeMssql extends LoadDataChange {
         returnList.add(new RawSqlStatement(MssqlUtil.generateIdentityInsertSql("OFF", catalogName, schemaName, tableName, database)));
 
         return returnList.toArray(new SqlStatement[0]);
+    }
+
+    @Override
+    public boolean supports(final Database database) {
+        return database instanceof MSSQLDatabase;
     }
 }

--- a/src/main/java/liquibase/ext/mssql/change/LoadUpdateDataChangeMssql.java
+++ b/src/main/java/liquibase/ext/mssql/change/LoadUpdateDataChangeMssql.java
@@ -5,6 +5,7 @@ import liquibase.change.DatabaseChange;
 import liquibase.change.core.LoadDataChange;
 import liquibase.change.core.LoadUpdateDataChange;
 import liquibase.database.Database;
+import liquibase.database.core.MSSQLDatabase;
 import liquibase.ext.mssql.MssqlUtil;
 import liquibase.statement.ExecutablePreparedStatementBase;
 import liquibase.statement.SqlStatement;
@@ -50,5 +51,10 @@ public class LoadUpdateDataChangeMssql extends LoadUpdateDataChange {
         returnList.add(new RawSqlStatement(MssqlUtil.generateIdentityInsertSql("OFF", catalogName, schemaName, tableName, database)));
 
         return returnList.toArray(new SqlStatement[0]);
+    }
+
+    @Override
+    public boolean supports(final Database database) {
+        return database instanceof MSSQLDatabase;
     }
 }


### PR DESCRIPTION
Changeset validation requires changes that extend standard changes to implement the supports method to ensure that they are only applied to applicable databases. Added the supports method to the LoadDataChangeMssql and LoadUpdateDataChangeMssql to conform with this requirement and only allow these changes to be used for the MSSQLDatabase.
